### PR TITLE
feat(nix): add flake with rustPlatform.buildRustPackage derivation an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/result
 /tmp
 /docs/book
 /node_modules

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  description = "Open Sesame - Vimium-style window switcher for COSMIC desktop";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (system: {
+        default = (pkgsFor system).callPackage ./nix/package.nix { };
+        open-sesame = self.packages.${system}.default;
+      });
+
+      overlays.default = final: prev: {
+        open-sesame = final.callPackage ./nix/package.nix { };
+      };
+
+      homeManagerModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.programs.open-sesame;
+          tomlFormat = pkgs.formats.toml { };
+          defaultPkg = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        in
+        {
+          options.programs.open-sesame = {
+            enable = lib.mkEnableOption "Open Sesame window switcher for COSMIC desktop";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = defaultPkg;
+              description = "The open-sesame package to use.";
+            };
+
+            settings = lib.mkOption {
+              type = tomlFormat.type;
+              default = { };
+              example = lib.literalExpression ''
+                {
+                  settings = {
+                    activation_key = "alt+space";
+                    overlay_delay = 720;
+                    quick_switch_threshold = 250;
+                    background_color = "#000000c8";
+                    card_color = "#1e1e1ef0";
+                    text_color = "#ffffffff";
+                    hint_color = "#646464ff";
+                  };
+                  keys.g = {
+                    apps = [ "ghostty" "com.mitchellh.ghostty" ];
+                    launch = "ghostty";
+                  };
+                  keys.f = {
+                    apps = [ "firefox" "org.mozilla.firefox" ];
+                    launch = "firefox";
+                  };
+                }
+              '';
+              description = ''
+                Configuration for Open Sesame, written to
+                {file}`~/.config/open-sesame/config.toml`.
+
+                See {command}`sesame --print-config` for default values
+                and https://scopecreep-zip.github.io/open-sesame/ for documentation.
+              '';
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+
+            xdg.configFile."open-sesame/config.toml" = lib.mkIf (cfg.settings != { }) {
+              source = tomlFormat.generate "open-sesame-config" cfg.settings;
+            };
+          };
+        };
+
+      devShells = forAllSystems (system:
+        let pkgs = pkgsFor system;
+        in {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+            packages = with pkgs; [
+              cargo
+              rustc
+              rust-analyzer
+              clippy
+              rustfmt
+            ];
+          };
+        });
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  installShellFiles,
+  fontconfig,
+  wayland,
+  wayland-protocols,
+  libxkbcommon,
+}:
+
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+
+  src = ./..;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    outputHashes = {
+      "cosmic-client-toolkit-0.1.0" = "sha256-KvXQJ/EIRyrlmi80WKl2T9Bn+j7GCfQlcjgcEVUxPkc=";
+      "cosmic-protocols-0.1.0" = "sha256-KvXQJ/EIRyrlmi80WKl2T9Bn+j7GCfQlcjgcEVUxPkc=";
+    };
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    fontconfig
+    wayland
+    wayland-protocols
+    libxkbcommon
+  ];
+
+  # Build only the main binary, not xtask
+  cargoBuildFlags = [ "--package" "open-sesame" ];
+  cargoTestFlags = [ "--package" "open-sesame" ];
+
+  # Tests that create $HOME/.cache/ dirs fail in the nix sandbox (/homeless-shelter)
+  # Standard nixpkgs pattern — used by atuin, spacetimedb, zabbix-cli, nushell, etc.
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # Generate man pages and shell completions via xtask
+  postBuild = ''
+    cargo run --package xtask -- man
+    cargo run --package xtask -- completions
+  '';
+
+  postInstall = ''
+    installManPage target/man/sesame.1.gz
+
+    installShellCompletion --cmd sesame \
+      --bash target/completions/sesame.bash \
+      --zsh target/completions/_sesame \
+      --fish target/completions/sesame.fish
+
+    install -Dm644 config.example.toml $out/share/doc/open-sesame/config.example.toml
+  '';
+
+  meta = with lib; {
+    description = "Vimium-style window switcher for COSMIC desktop";
+    homepage = "https://github.com/ScopeCreep-zip/open-sesame";
+    license = licenses.gpl3Only;
+    maintainers = [ ];
+    platforms = platforms.linux;
+    mainProgram = "sesame";
+  };
+}


### PR DESCRIPTION
…d home-manager module

Add nix flake packaging for open-sesame with three distribution interfaces:
- `nix build` / `nix run` / `nix profile install` via packages.${system}.default
- `programs.open-sesame.enable = true` via homeManagerModules.default
- `pkgs.open-sesame` via overlays.default

nix/package.nix:
- rustPlatform.buildRustPackage with cargoLock.lockFile for git dep support
- outputHashes for cosmic-client-toolkit-0.1.0 and cosmic-protocols-0.1.0 from pop-os/cosmic-protocols@d0e95be
- version auto-read from Cargo.toml via builtins.fromTOML (zero manual sync)
- nativeBuildInputs: pkg-config, installShellFiles
- buildInputs: fontconfig, wayland, wayland-protocols, libxkbcommon
- cargoBuildFlags/cargoTestFlags scoped to --package open-sesame (skips xtask)
- preCheck exports HOME=$(mktemp -d) for sandbox-incompatible cache dir tests
- postBuild runs xtask to generate man page and shell completions
- postInstall uses installManPage and installShellCompletion --cmd sesame
- installs config.example.toml to $out/share/doc/open-sesame/

flake.nix:
- inputs: nixpkgs (nixos-unstable only, no home-manager input required)
- packages output for x86_64-linux and aarch64-linux
- homeManagerModules.default defined inline with self closure for default package resolution (Hyprland pattern — no overlay required by consumers)
- home-manager module provides programs.open-sesame.{enable,package,settings}
- settings uses pkgs.formats.toml freeform type with xdg.configFile generation
- devShells output with all native build dependencies for contributors
- overlays.default exposes pkgs.open-sesame via callPackage

.gitignore: add /result (nix build output symlink)
flake.lock: pin nixpkgs nixos-unstable