### PR TITLE
fix: respect HiDPI scale factor on Wayland

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -397,6 +397,11 @@ impl CompositorHandler for App {
         new_factor: i32,
     ) {
         self.renderer.set_scale(new_factor as f32);
+
+        // Tell compositor about the buffer scale
+        if let Some(ref layer_surface) = self.layer_surface {
+            layer_surface.wl_surface().set_buffer_scale(new_factor);
+        }
     }
 
     fn transform_changed(

--- a/src/app/renderer.rs
+++ b/src/app/renderer.rs
@@ -80,9 +80,17 @@ impl Renderer {
             return None;
         }
 
-        // Initialize pool if needed
+        // Create overlay and render first to get actual pixmap dimensions
+        let overlay = Overlay::new(self.width, self.height, self.scale, config);
+        let pixmap = if show_full {
+            overlay.render_full(hints, input, selected_index)?
+        } else {
+            overlay.render_initial()?
+        };
+
+        // Initialize pool based on actual pixmap size (physical/scaled dimensions)
         if self.pool.is_none() {
-            let size = (self.width * self.height * 4) as usize;
+            let size = (pixmap.width() * pixmap.height() * 4) as usize;
             match SlotPool::new(size, shm) {
                 Ok(pool) => self.pool = Some(pool),
                 Err(e) => {
@@ -93,14 +101,6 @@ impl Renderer {
         }
 
         let pool = self.pool.as_mut()?;
-
-        // Create overlay and render
-        let overlay = Overlay::new(self.width, self.height, self.scale, config);
-        let pixmap = if show_full {
-            overlay.render_full(hints, input, selected_index)?
-        } else {
-            overlay.render_initial()?
-        };
 
         let stride = pixmap.width() as i32 * 4;
 


### PR DESCRIPTION
- Add wl_surface.set_buffer_scale() call in scale_factor_changed to notify compositor of buffer scale
- Move SHM pool initialization after pixmap creation to use actual physical dimensions instead of logical dimensions

This fixes the overlay appearing too large on HiDPI displays with 200% scaling.