### PR TITLE
fix(ci): extract build-rpm.sh, add jq/nix-cache, gate release on test workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+        with:
+          use-flakehub: false
+          diagnostic-endpoint: ""
+
       - uses: cachix/cachix-action@v15
         with:
           name: scopecreep-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -33,6 +35,10 @@ jobs:
   semantic-release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     outputs:
       new_release: ${{ steps.release.outputs.new_release }}
       version: ${{ steps.release.outputs.version }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -684,16 +684,7 @@ mise run cargo:rpm:assemble-scriptlets
 cargo build --release --target ${TARGET}
 mise run docs:man
 mise run docs:completions
-
-# Inject version floor for desktop requires and sign with GPG key
-VERSION=$(cargo metadata --format-version=1 -q | python3 -c "import sys,json; [print(p['version']) for p in json.load(sys.stdin)['packages'] if p['name']=='open-sesame']")
-SIGN_ARGS=()
-if [ -n "${GPG_SIGNING_KEY_FILE:-}" ]; then
-  SIGN_ARGS=(--signing-key "$GPG_SIGNING_KEY_FILE")
-fi
-cargo generate-rpm -p open-sesame --payload-compress gzip --target ${TARGET} "${SIGN_ARGS[@]}"
-cargo generate-rpm -p daemon-wm --payload-compress gzip --target ${TARGET} \
-  -s "requires.open-sesame = \">= ${VERSION}\"" "${SIGN_ARGS[@]}"
+./scripts/rpm/build-rpm.sh
 """
 
 [tasks."ci:build:rpm:arm64"]
@@ -708,15 +699,7 @@ mise run cargo:rpm:assemble-scriptlets
 cargo build --release --target ${TARGET}
 mise run docs:man
 mise run docs:completions
-
-VERSION=$(cargo metadata --format-version=1 -q | python3 -c "import sys,json; [print(p['version']) for p in json.load(sys.stdin)['packages'] if p['name']=='open-sesame']")
-SIGN_ARGS=()
-if [ -n "${GPG_SIGNING_KEY_FILE:-}" ]; then
-  SIGN_ARGS=(--signing-key "$GPG_SIGNING_KEY_FILE")
-fi
-cargo generate-rpm -p open-sesame --payload-compress gzip --target ${TARGET} "${SIGN_ARGS[@]}"
-cargo generate-rpm -p daemon-wm --payload-compress gzip --target ${TARGET} \
-  -s "requires.open-sesame = \">= ${VERSION}\"" "${SIGN_ARGS[@]}"
+./scripts/rpm/build-rpm.sh
 """
 
 [tasks."ci:release:rename-rpm"]

--- a/flake.nix
+++ b/flake.nix
@@ -526,6 +526,7 @@
               patchelf
               cargo-deb
               (pkgs.callPackage ./nix/cargo-generate-rpm.nix { })
+              jq
 
               # Documentation
               mdbook

--- a/scripts/rpm/build-rpm.sh
+++ b/scripts/rpm/build-rpm.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# build-rpm.sh — build both open-sesame RPMs with version-locked desktop requires and optional signing.
+# Called by ci:build:rpm and ci:build:rpm:arm64 mise tasks.
+#
+# Environment:
+#   TARGET                 — cargo target triple (required)
+#   GPG_SIGNING_KEY_FILE   — path to PGP private key for --signing-key (optional)
+set -euo pipefail
+
+: "${TARGET:?TARGET must be set (e.g. x86_64-unknown-linux-gnu)}"
+
+# Extract workspace version from Cargo metadata
+VERSION=$(cargo metadata --format-version=1 -q \
+  | jq -r '.packages[] | select(.name == "open-sesame") | .version')
+
+# Build signing arguments if key file is provided
+SIGN_ARGS=()
+if [ -n "${GPG_SIGNING_KEY_FILE:-}" ]; then
+  SIGN_ARGS=(--signing-key "$GPG_SIGNING_KEY_FILE")
+fi
+
+# Write version-locked requires override to a temp file (avoids shell escaping)
+OVERRIDES="$(mktemp)"
+trap 'rm -f "$OVERRIDES"' EXIT
+cat > "$OVERRIDES" <<EOF
+[requires]
+open-sesame = ">= ${VERSION}"
+EOF
+
+echo "==> Building headless .rpm (open-sesame) v${VERSION}..."
+cargo generate-rpm -p open-sesame \
+  --payload-compress gzip \
+  --target "${TARGET}" \
+  "${SIGN_ARGS[@]}"
+
+echo "==> Building desktop .rpm (open-sesame-desktop) v${VERSION} requires open-sesame >= ${VERSION}..."
+cargo generate-rpm -p daemon-wm \
+  --payload-compress gzip \
+  --target "${TARGET}" \
+  --metadata-overwrite "$OVERRIDES" \
+  "${SIGN_ARGS[@]}"


### PR DESCRIPTION
Fix RPM build failure from v1.15.0 release: inline TOML escaping in mise task broke cargo-generate-rpm `-s` flag parsing.

- Extract RPM build logic to `scripts/rpm/build-rpm.sh` using `--metadata-overwrite` temp file instead of `-s` inline TOML
- Replace python3 with jq for version extraction; add jq to flake.nix devShell
- Gate release workflow on Test workflow completion via `workflow_run` trigger
- Add `DeterminateSystems/magic-nix-cache-action@v8` to nix.yml for CI-local nix store caching