### PR TITLE
fix(nix): update cosmic-theme outputHash after upstream libcosmic force-push

### DIFF
--- a/nix/package-desktop.nix
+++ b/nix/package-desktop.nix
@@ -83,7 +83,7 @@ rustPlatform.buildRustPackage {
       "cosmic-client-toolkit-0.2.0" = "sha256-hqsOzu0mlkE2jtgL5HvbT9vtOKiMSniNwV+xk4UzTkc=";
       "cosmic-protocols-0.2.0" = "sha256-hqsOzu0mlkE2jtgL5HvbT9vtOKiMSniNwV+xk4UzTkc=";
       "atomicwrites-0.4.2" = "sha256-QZSuGPrJXh+svMeFWqAXoqZQxLq/WfIiamqvjJNVhxA=";
-      "cosmic-theme-1.0.0" = "sha256-2By9fKPXsNhoCP1Npyoi3bG8a8Bb15cEXewK6ea0WWo=";
+      "cosmic-theme-1.0.0" = "sha256-NmlqK+vBzCg0hpF+WHKpi+EqVLNPz8ggQWBdCblVVDU=";
       "smithay-clipboard-0.8.0" = "sha256-GojAFRbhJcP0Rpr+v9WOivgW9x38PZdeBWTbMhkDB3A=";
       "window_clipboard-0.4.1" = "sha256-WO3JFbE+6ESRAfkxrnEFeZyGuhUHLOKOVHcGQyHwoK0=";
       "nucleo-0.5.0" = "sha256-Hm4SxtTSBrcWpXrtSqeO0TACbUxq3gizg1zD/6Yw/sI=";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -83,7 +83,7 @@ rustPlatform.buildRustPackage {
       "cosmic-client-toolkit-0.2.0" = "sha256-hqsOzu0mlkE2jtgL5HvbT9vtOKiMSniNwV+xk4UzTkc=";
       "cosmic-protocols-0.2.0" = "sha256-hqsOzu0mlkE2jtgL5HvbT9vtOKiMSniNwV+xk4UzTkc=";
       "atomicwrites-0.4.2" = "sha256-QZSuGPrJXh+svMeFWqAXoqZQxLq/WfIiamqvjJNVhxA=";
-      "cosmic-theme-1.0.0" = "sha256-2By9fKPXsNhoCP1Npyoi3bG8a8Bb15cEXewK6ea0WWo=";
+      "cosmic-theme-1.0.0" = "sha256-NmlqK+vBzCg0hpF+WHKpi+EqVLNPz8ggQWBdCblVVDU=";
       "smithay-clipboard-0.8.0" = "sha256-GojAFRbhJcP0Rpr+v9WOivgW9x38PZdeBWTbMhkDB3A=";
       "window_clipboard-0.4.1" = "sha256-WO3JFbE+6ESRAfkxrnEFeZyGuhUHLOKOVHcGQyHwoK0=";
       "nucleo-0.5.0" = "sha256-Hm4SxtTSBrcWpXrtSqeO0TACbUxq3gizg1zD/6Yw/sI=";


### PR DESCRIPTION
Update cosmic-theme-1.0.0 outputHash in nix/package.nix and nix/package-desktop.nix. Verified locally: both nix build .#packages.x86_64-linux.open-sesame and open-sesame-desktop succeed with all tests passing.